### PR TITLE
Vector example pop functions fix proposal

### DIFF
--- a/Sem. 09/Solutions/Vector (with move)/Vector.cpp
+++ b/Sem. 09/Solutions/Vector (with move)/Vector.cpp
@@ -127,7 +127,7 @@ Test Vector::popBack() {
 	// Note: the actual std::vector does NOT lower its capacity on this function
 	//downsizeIfNeeded();
 	// Note: the actual std::vector does NOT return on popback
-	return data[size--];
+	return data[--size];
 }
 
 Test Vector::popAt(size_t index) {
@@ -141,7 +141,7 @@ Test Vector::popAt(size_t index) {
 		data[i] = data[i + 1];
 	}
 
-	return data[index];
+	return temp;
 }
 
 bool Vector::empty() const {


### PR DESCRIPTION
popBack() should return data[--size], because data[size--] won't return the right index of the last element

popAt(size_t index) should return the already saved temp variable